### PR TITLE
Supress warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
 excerpt_separator: ""
-pygments: true
 markdown: kramdown
 url: http://estadoperfecto.github.io
 title: El Estado Perfecto


### PR DESCRIPTION
You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.
